### PR TITLE
Add branch enforcement PR checker

### DIFF
--- a/.github/workflows/branch_enforcer.yml
+++ b/.github/workflows/branch_enforcer.yml
@@ -1,0 +1,14 @@
+name: 'Check Branch'
+
+on:
+  pull_request:
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: (github.base_ref == 'PROD' && github.head_ref != 'PROD-STAGE') || (github.base_ref == 'PROD-STAGE' && github.head_ref != 'TEST') || (github.base_ref == 'TEST' && github.head_ref != 'TEST-STAGE')
+        run: |
+          echo "ERROR: You can only merge to main from dev."
+          exit 1


### PR DESCRIPTION
Script will only allow branches to flow up the stream towards prod. Cannot skip branches.